### PR TITLE
feat(auth): cookie-based refresh + CSRF (M4.T1)

### DIFF
--- a/apps/api/alembic/versions/0009_add_users_and_sessions.py
+++ b/apps/api/alembic/versions/0009_add_users_and_sessions.py
@@ -1,0 +1,70 @@
+"""Add users and user_sessions tables
+
+Revision ID: 0009_add_users_and_sessions
+Revises: 0008_outbox_retry_fields
+Create Date: 2025-09-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0009_add_users_and_sessions"
+down_revision = "0008_outbox_retry_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # users table
+    op.create_table(
+        "users",
+        sa.Column("id", sa.UUID(), primary_key=True, nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("username", sa.String(), nullable=True),
+        sa.Column("password_hash", sa.String(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "roles",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[""user""]'"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_users_email", "users", ["email"], unique=True)
+    op.create_index("ix_users_username", "users", ["username"], unique=True)
+    op.create_index("ix_users_created_at", "users", ["created_at"], unique=False)
+
+    # user_sessions table
+    op.create_table(
+        "user_sessions",
+        sa.Column("id", sa.UUID(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.UUID(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("refresh_id", sa.UUID(), nullable=False),
+        sa.Column("user_agent", sa.String(), nullable=True),
+        sa.Column("ip_address", sa.String(), nullable=True),
+        sa.Column("issued_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_user_sessions_user_id", "user_sessions", ["user_id"], unique=False)
+    op.create_index("ix_user_sessions_refresh_id", "user_sessions", ["refresh_id"], unique=True)
+    op.create_index("ix_user_sessions_issued_at", "user_sessions", ["issued_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_sessions_issued_at", table_name="user_sessions")
+    op.drop_index("ix_user_sessions_refresh_id", table_name="user_sessions")
+    op.drop_index("ix_user_sessions_user_id", table_name="user_sessions")
+    op.drop_table("user_sessions")
+
+    op.drop_index("ix_users_created_at", table_name="users")
+    op.drop_index("ix_users_username", table_name="users")
+    op.drop_index("ix_users_email", table_name="users")
+    op.drop_table("users")
+

--- a/apps/api/app/api/v1/auth.py
+++ b/apps/api/app/api/v1/auth.py
@@ -3,19 +3,42 @@ from __future__ import annotations
 # Third-party imports
 import jwt
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+import uuid
+from pydantic import BaseModel, EmailStr, Field
 
 # Local imports
-from app.infra.auth import create_access_token, create_refresh_token, get_current_user
+from app.infra.auth import (
+    create_access_token,
+    create_refresh_token,
+    create_verify_token,
+    get_current_user,
+)
+from app.infra.db import get_session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from app.infra.models import User
+from app.infra.security import hash_password, verify_password
+from app.infra.ratelimit import allow
 from app.settings import settings
 
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8)
+    username: str | None = None
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
 class LoginRequest(BaseModel):
-    username: str
+    email: str | None = None
+    username: str | None = None
     password: str
 
 
@@ -24,19 +47,108 @@ class RefreshRequest(BaseModel):
 
 
 @router.post("/login")
-async def login(body: LoginRequest) -> dict[str, str]:
-    """Password login (demo: credentials via settings, defaults for dev)."""
-    expected_user = settings.demo_username or "demo"
-    expected_pass = settings.demo_password or ("demo" + "123")  # not a real secret
-    if body.username == expected_user and body.password == expected_pass:
-        user_id = "123e4567-e89b-12d3-a456-426614174000"
-    else:
+async def login(body: LoginRequest, request: Request, s: AsyncSession = Depends(get_session)) -> dict[str, str]:
+    """Login endpoint supports two modes: demo (flag off) and real (flag on)."""
+    if not settings.user_mgmt_enabled:
+        # Demo login (existing behavior)
+        expected_user = settings.demo_username or "demo"
+        expected_pass = settings.demo_password or ("demo" + "123")  # not a real secret
+        if (body.username or body.email) == expected_user and body.password == expected_pass:
+            user_id = "123e4567-e89b-12d3-a456-426614174000"
+        else:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        return {
+            "access_token": create_access_token(user_id),
+            "refresh_token": create_refresh_token(user_id),
+            "token_type": "bearer",
+        }
+
+    # Real login (flag on)
+    key = f"login:{(body.email or body.username or '').lower()}"
+    if not allow(key, settings.rate_limit_max_attempts, settings.rate_limit_window_seconds):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Please try again later")
+
+    stmt = select(User).where(User.email == (body.email or ""))
+    res = await s.execute(stmt)
+    user = res.scalars().first()
+    ok = bool(
+        user
+        and user.is_active
+        and user.password_hash
+        and verify_password(user.password_hash, body.password)
+        and (user.is_verified or not settings.auth_require_email_verify)
+    )
+    if not ok:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
     return {
-        "access_token": create_access_token(user_id),
-        "refresh_token": create_refresh_token(user_id),
+        "access_token": create_access_token(str(user.id), scopes=user.roles),
+        "refresh_token": create_refresh_token(str(user.id)),  # rotation in M1.T3
         "token_type": "bearer",
     }
+
+
+@router.post("/register", status_code=202)
+async def register(
+    body: RegisterRequest, request: Request, s: AsyncSession = Depends(get_session)
+) -> dict[str, str | None]:
+    if not settings.user_mgmt_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    key = f"register:{request.client.host if request.client else 'unknown'}"
+    if not allow(key, settings.rate_limit_max_attempts, settings.rate_limit_window_seconds):
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Please try again later")
+
+    # Do not enumerate existing emails
+    res = await s.execute(select(User).where(User.email == body.email))
+    existing = res.scalars().first()
+    if existing:
+        return {"message": "If this address can register, a verification will be sent.", "dev_verify_token": None}
+
+    user = User(email=body.email, username=body.username, password_hash=hash_password(body.password))
+    s.add(user)
+    await s.commit()
+    await s.refresh(user)
+
+    token = create_verify_token(str(user.id))
+    return {
+        "message": "Verification required",
+        "dev_verify_token": token if settings.testing else None,
+    }
+
+
+@router.post("/verify-email", status_code=204, response_class=Response)
+async def verify_email(body: VerifyEmailRequest, s: AsyncSession = Depends(get_session)) -> Response:
+    if not settings.user_mgmt_enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    try:
+        decoded = jwt.decode(
+            body.token,
+            settings.jwt_secret,
+            algorithms=["HS256"],
+            audience=settings.jwt_aud,
+            options={"require": ["exp", "iat"]},
+        )
+    except jwt.PyJWTError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token") from e
+
+    if decoded.get("typ") != "verify":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token type")
+
+    uid = decoded.get("sub")
+    if not uid:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token")
+
+    res = await s.execute(select(User).where(User.id == uuid.UUID(uid)))
+    user = res.scalars().first()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User not found")
+
+    user.is_verified = True
+    await s.merge(user)
+    await s.commit()
+    return Response(status_code=204)
 
 
 @router.post("/demo")

--- a/apps/api/app/infra/auth.py
+++ b/apps/api/app/infra/auth.py
@@ -33,7 +33,7 @@ def create_access_token(sub: str, scopes: list[str] | None = None) -> str:
     return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
 
 
-def create_refresh_token(sub: str) -> str:
+def create_refresh_token(sub: str, refresh_id: str | None = None) -> str:
     now = _utcnow()
     payload = {
         "iss": settings.jwt_iss,
@@ -44,6 +44,8 @@ def create_refresh_token(sub: str) -> str:
         "sub": sub,
         "typ": "refresh",
     }
+    if refresh_id:
+        payload["rid"] = refresh_id
     return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
 
 

--- a/apps/api/app/infra/auth.py
+++ b/apps/api/app/infra/auth.py
@@ -47,6 +47,20 @@ def create_refresh_token(sub: str) -> str:
     return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
 
 
+def create_verify_token(sub: str, minutes: int = 30) -> str:
+    now = _utcnow()
+    payload = {
+        "iss": settings.jwt_iss,
+        "aud": settings.jwt_aud,
+        "iat": int(now.timestamp()),
+        "nbf": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=minutes)).timestamp()),
+        "sub": sub,
+        "typ": "verify",
+    }
+    return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+
 def require_user(creds: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> str:
     if not creds:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing auth")

--- a/apps/api/app/infra/models.py
+++ b/apps/api/app/infra/models.py
@@ -11,6 +11,7 @@ from pydantic import field_validator
 
 # Third-party imports
 from sqlalchemy import JSON, Column, event
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Field, SQLModel
 
 
@@ -97,3 +98,51 @@ class ProcessedEvent(SQLModel, table=True):
     processed_at: datetime = Field(default_factory=datetime.utcnow, index=True)
     outcome: str = Field(default="ok")
     attempts: int = Field(default=1)
+
+
+# ==============================
+# User Management Models (flagged rollout)
+# ==============================
+
+
+class User(SQLModel, table=True):
+    """Persistent application user.
+
+    Fields chosen for minimal viable user management with future-proofing:
+    - Unique email, optional username
+    - Optional password_hash (set when password auth is enabled)
+    - Roles as JSON list (JSONB in Postgres) for simple RBAC
+    - Activity and verification flags
+    - Timestamps
+    """
+
+    __tablename__ = "users"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, nullable=False)
+    email: str = Field(index=True, unique=True, nullable=False)
+    username: str | None = Field(default=None, index=True)
+    password_hash: str | None = Field(default=None)
+    is_active: bool = Field(default=True, nullable=False)
+    is_verified: bool = Field(default=False, nullable=False)
+    roles: list[str] = Field(default_factory=lambda: ["user"], sa_column=Column(JSONB, nullable=False))
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False, index=True)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class UserSession(SQLModel, table=True):
+    """Server-side refresh session record.
+
+    Tracks refresh token identity (refresh_id) by UUID, with lifecycle fields for rotation and revocation.
+    """
+
+    __tablename__ = "user_sessions"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, nullable=False)
+    user_id: UUID = Field(foreign_key="users.id", index=True, nullable=False)
+    refresh_id: UUID = Field(default_factory=uuid4, unique=True, index=True, nullable=False)
+    user_agent: str | None = None
+    ip_address: str | None = None
+    issued_at: datetime = Field(default_factory=datetime.utcnow, nullable=False, index=True)
+    last_used_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    expires_at: datetime = Field(nullable=False)
+    revoked_at: datetime | None = Field(default=None)

--- a/apps/api/app/infra/ratelimit.py
+++ b/apps/api/app/infra/ratelimit.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Dict, Tuple
+
+
+_state: Dict[str, Tuple[float, int]] = defaultdict(lambda: (0.0, 0))
+
+
+def allow(key: str, max_attempts: int, window_seconds: int) -> bool:
+    now = time.time()
+    win_start, count = _state[key]
+    if now - win_start > window_seconds:
+        _state[key] = (now, 1)
+        return True
+    if count < max_attempts:
+        _state[key] = (win_start, count + 1)
+        return True
+    return False
+

--- a/apps/api/app/infra/security.py
+++ b/apps/api/app/infra/security.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+
+_ph = PasswordHasher()  # Argon2id defaults
+
+
+def hash_password(pw: str) -> str:
+    return _ph.hash(pw)
+
+
+def verify_password(hash_: str, pw: str) -> bool:
+    try:
+        return _ph.verify(hash_, pw)
+    except VerifyMismatchError:
+        return False
+    except Exception:
+        return False
+

--- a/apps/api/app/infra/sessions.py
+++ b/apps/api/app/infra/sessions.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.infra.models import UserSession
+from app.settings import settings
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+async def create_session(
+    db: AsyncSession, user_id: UUID, ua: Optional[str], ip: Optional[str]
+) -> UserSession:
+    now = _utcnow()
+    sess = UserSession(
+        user_id=user_id,
+        refresh_id=uuid4(),
+        user_agent=ua,
+        ip_address=ip,
+        issued_at=now,
+        last_used_at=now,
+        expires_at=now + timedelta(days=settings.refresh_token_days),
+        revoked_at=None,
+    )
+    db.add(sess)
+    await db.commit()
+    await db.refresh(sess)
+    return sess
+
+
+async def get_session_by_refresh_id(db: AsyncSession, rid: UUID) -> UserSession | None:
+    res = await db.execute(select(UserSession).where(UserSession.refresh_id == rid))
+    return res.scalars().first()
+
+
+async def touch_session(db: AsyncSession, sess: UserSession) -> None:
+    sess.last_used_at = _utcnow()
+    db.add(sess)
+    await db.commit()
+
+
+async def revoke_session(db: AsyncSession, sess: UserSession) -> None:
+    if not sess.revoked_at:
+        sess.revoked_at = _utcnow()
+        db.add(sess)
+        await db.commit()
+

--- a/apps/api/app/settings.py
+++ b/apps/api/app/settings.py
@@ -20,6 +20,9 @@ class Settings(BaseSettings):
     auto_embed_mode: str = "event"  # "event" | "inline" | "off"
     # Feature flags
     user_mgmt_enabled: bool = False
+    auth_require_email_verify: bool = True
+    rate_limit_window_seconds: int = 60
+    rate_limit_max_attempts: int = 5
 
     # Demo credentials for development/testing (override via env in real deployments)
     demo_username: str = "demo"

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.36.0",
     "markdown-it-py>=4.0.0",
     "bleach>=6.2.0",
+    "argon2-cffi>=23.1.0",
 ]
 
 [tool.uv]

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -21,8 +21,8 @@ from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession, c
 from sqlalchemy.orm import sessionmaker
 
 from alembic import command
-from app.infra.db import build_engine, get_session
 from app.infra.auth import require_user
+from app.infra.db import build_engine, get_session
 from app.infra.models import Entry
 from app.main import app
 from app.settings import settings

--- a/apps/api/tests/integration/test_auth_password_flow.py
+++ b/apps/api/tests/integration/test_auth_password_flow.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pytest
+
+from app.settings import settings
+from pathlib import Path
+from alembic.config import Config
+from alembic import command
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio()
+async def test_register_verify_login(client):
+    # Enable user management for this test
+    settings.user_mgmt_enabled = True
+    # Ensure DB is at head (test DB may have been created earlier without latest migration)
+    cfg = Config(str(Path(__file__).resolve().parents[2] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", settings.db_url)
+    command.upgrade(cfg, "head")
+
+    # Register
+    r = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "auth.t2@example.com", "password": "CorrectHorse9!", "username": "auth2"},
+    )
+    assert r.status_code == 202, r.text
+    data = r.json()
+    token = data.get("dev_verify_token")
+    # In testing mode we expect a dev token
+    assert token is not None
+
+    # Verify email
+    r = await client.post("/api/v1/auth/verify-email", json={"token": token})
+    assert r.status_code == 204, r.text
+
+    # Login
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "auth.t2@example.com", "password": "CorrectHorse9!"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "access_token" in body and "refresh_token" in body and body["token_type"] == "bearer"

--- a/apps/api/tests/integration/test_auth_user_management_scaffold.py
+++ b/apps/api/tests/integration/test_auth_user_management_scaffold.py
@@ -7,6 +7,7 @@ user management implementation. Replace skips when functionality is ready.
 from __future__ import annotations
 
 import pytest
+
 from httpx import AsyncClient
 
 
@@ -16,49 +17,53 @@ pytestmark = pytest.mark.integration
 @pytest.mark.skip(reason="Pending user management implementation")
 @pytest.mark.asyncio()
 async def test_login_logout_refresh_flow(client: AsyncClient) -> None:
-  """Happy-path: login -> refresh -> logout."""
-  # Login with credentials
-  res = await client.post(
-    "/api/v1/auth/login",
-    json={"username": "demo@example.com", "password": "password"},
-  )
-  assert res.status_code == 200
-  data = res.json()
-  assert "access_token" in data and "refresh_token" in data
+    """Happy-path: login -> refresh -> logout."""
+    # Login with credentials
+    res = await client.post(
+        "/api/v1/auth/login",
+        json={"username": "demo@example.com", "password": "password"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert "access_token" in data and "refresh_token" in data
 
-  # Refresh access token
-  res2 = await client.post(
-    "/api/v1/auth/refresh", json={"refresh_token": data["refresh_token"]}
-  )
-  assert res2.status_code == 200
+    # Refresh access token
+    res2 = await client.post(
+        "/api/v1/auth/refresh", json={"refresh_token": data["refresh_token"]}
+    )
+    assert res2.status_code == 200
 
-  # Logout (invalidate session) – subsequent use of token should fail
-  res3 = await client.post("/api/v1/auth/logout", headers={"Authorization": f"Bearer {data['access_token']}"})
-  assert res3.status_code == 200
+    # Logout (invalidate session) - subsequent use of token should fail
+    res3 = await client.post(
+        "/api/v1/auth/logout",
+        headers={"Authorization": f"Bearer {data['access_token']}"},
+    )
+    assert res3.status_code == 200
 
 
 @pytest.mark.skip(reason="Pending passkey integration")
 @pytest.mark.asyncio()
 async def test_passkey_register_and_authenticate(client: AsyncClient) -> None:
-  """Register a passkey then authenticate with it."""
-  # Begin registration -> verify -> store
-  r1 = await client.post("/api/v1/auth/webauthn/register/options", json={"userId": "user-1"})
-  assert r1.status_code == 200
-  # The rest depends on WebAuthn ceremony; will be mocked in test harness
-  assert "challenge" in r1.json()
+    """Register a passkey then authenticate with it."""
+    # Begin registration -> verify -> store
+    r1 = await client.post(
+        "/api/v1/auth/webauthn/register/options", json={"userId": "user-1"}
+    )
+    assert r1.status_code == 200
+    # The rest depends on WebAuthn ceremony; will be mocked in test harness
+    assert "challenge" in r1.json()
 
-  # Authentication options then verify
-  r2 = await client.post("/api/v1/auth/webauthn/authenticate/options")
-  assert r2.status_code == 200
+    # Authentication options then verify
+    r2 = await client.post("/api/v1/auth/webauthn/authenticate/options")
+    assert r2.status_code == 200
 
 
 @pytest.mark.skip(reason="Pending OAuth providers wiring")
 @pytest.mark.asyncio()
 async def test_oauth_provider_availability_and_connect(client: AsyncClient) -> None:
-  """Check provider availability and connect flow contract."""
-  r = await client.get("/api/v1/auth/oauth/google/available")
-  assert r.status_code in {200, 404}
+    """Check provider availability and connect flow contract."""
+    r = await client.get("/api/v1/auth/oauth/google/available")
+    assert r.status_code in {200, 404}
 
-  r2 = await client.post("/api/v1/auth/oauth/google/connect")
-  assert r2.status_code in {200, 302}
-
+    r2 = await client.post("/api/v1/auth/oauth/google/connect")
+    assert r2.status_code in {200, 302}

--- a/apps/api/tests/integration/test_permissions_scaffold.py
+++ b/apps/api/tests/integration/test_permissions_scaffold.py
@@ -7,6 +7,7 @@ authorization policies are implemented.
 from __future__ import annotations
 
 import pytest
+
 from httpx import AsyncClient
 
 
@@ -16,26 +17,25 @@ pytestmark = pytest.mark.integration
 @pytest.mark.skip(reason="Pending ownership enforcement")
 @pytest.mark.asyncio()
 async def test_owner_only_can_update_and_delete(client: AsyncClient) -> None:
-  """Only the owner can update/delete their entries."""
-  # Create entry as user A
-  a_headers = {"Authorization": "Bearer token-user-a"}
-  create = await client.post(
-    "/api/v1/entries",
-    json={"title": "Owned", "content": "X"},
-    headers=a_headers,
-  )
-  assert create.status_code == 201
-  entry_id = create.json()["id"]
+    """Only the owner can update/delete their entries."""
+    # Create entry as user A
+    a_headers = {"Authorization": "Bearer token-user-a"}
+    create = await client.post(
+        "/api/v1/entries",
+        json={"title": "Owned", "content": "X"},
+        headers=a_headers,
+    )
+    assert create.status_code == 201
+    entry_id = create.json()["id"]
 
-  # User B cannot update/delete
-  b_headers = {"Authorization": "Bearer token-user-b"}
-  upd = await client.put(
-    f"/api/v1/entries/{entry_id}",
-    json={"title": "Hijack", "expected_version": 1},
-    headers=b_headers,
-  )
-  assert upd.status_code in {401, 403}
+    # User B cannot update/delete
+    b_headers = {"Authorization": "Bearer token-user-b"}
+    upd = await client.put(
+        f"/api/v1/entries/{entry_id}",
+        json={"title": "Hijack", "expected_version": 1},
+        headers=b_headers,
+    )
+    assert upd.status_code in {401, 403}
 
-  dele = await client.delete(f"/api/v1/entries/{entry_id}", headers=b_headers)
-  assert dele.status_code in {401, 403}
-
+    dele = await client.delete(f"/api/v1/entries/{entry_id}", headers=b_headers)
+    assert dele.status_code in {401, 403}

--- a/apps/api/tests/integration/test_refresh_rotation.py
+++ b/apps/api/tests/integration/test_refresh_rotation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from app.settings import settings
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio()
+async def test_refresh_rotation_and_logout(client):
+    settings.user_mgmt_enabled = True
+
+    # Register
+    r = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "rot@example.com", "password": "CorrectHorse9!", "username": "rot"},
+    )
+    assert r.status_code == 202, r.text
+    token = r.json().get("dev_verify_token")
+    assert token
+
+    # Verify
+    r = await client.post("/api/v1/auth/verify-email", json={"token": token})
+    assert r.status_code == 204, r.text
+
+    # Login
+    r = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "rot@example.com", "password": "CorrectHorse9!"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    refresh1 = data["refresh_token"]
+
+    # Refresh -> should rotate
+    r = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh1})
+    assert r.status_code == 200, r.text
+    refresh2 = r.json()["refresh_token"]
+    assert refresh2 != refresh1
+
+    # Old refresh should now be invalid
+    r = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh1})
+    assert r.status_code == 401
+
+    # Logout current session
+    r = await client.post("/api/v1/auth/logout", json={"refresh_token": refresh2})
+    assert r.status_code == 204
+
+    # Refresh with revoked token should fail
+    r = await client.post("/api/v1/auth/refresh", json={"refresh_token": refresh2})
+    assert r.status_code == 401
+

--- a/apps/api/tests/unit/test_user_model.py
+++ b/apps/api/tests/unit/test_user_model.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from app.infra.models import User
+
+
+def test_user_defaults() -> None:
+    u = User(email="x@example.com")
+    assert u.is_active is True
+    assert u.is_verified is False
+    assert isinstance(u.roles, list)
+    assert "user" in u.roles
+

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version < '3.13'",
 ]
 
@@ -41,6 +42,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]
@@ -231,8 +276,12 @@ wheels = [
 name = "cffi"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
@@ -270,6 +319,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475, upload-time = "2024-09-04T20:44:43.733Z" },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009, upload-time = "2024-09-04T20:44:45.309Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+]
+dependencies = [
+    { name = "pycparser", marker = "python_full_version >= '3.14' and implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -440,7 +562,8 @@ name = "cryptography"
 version = "45.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
+    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/35/c495bffc2056f2dadb32434f1feedd79abde2a7f8363e1974afa9c33c7e2/cryptography-45.0.7.tar.gz", hash = "sha256:4b1654dfc64ea479c242508eb8c724044f1e964a47d1d1cacc5132292d851971", size = 744980, upload-time = "2025-09-01T11:15:03.146Z" }
 wheels = [
@@ -1013,6 +1136,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "argon2-cffi" },
     { name = "asyncpg" },
     { name = "bleach" },
     { name = "fastapi", extra = ["standard"] },
@@ -1065,6 +1189,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13.2" },
+    { name = "argon2-cffi", specifier = ">=23.1.0" },
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "bleach", specifier = ">=6.2.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.115.0" },

--- a/apps/web/src/components/__tests__/JournalApp.smoke.test.tsx
+++ b/apps/web/src/components/__tests__/JournalApp.smoke.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 
 // Mock API service used by JournalApp
 vi.mock('../../services/api', () => {
@@ -43,4 +42,3 @@ describe('JournalApp smoke', () => {
     expect(await screen.findByText('First')).toBeDefined();
   });
 });
-

--- a/apps/web/src/components/layout/__tests__/EntryList.a11y.test.tsx
+++ b/apps/web/src/components/layout/__tests__/EntryList.a11y.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 import { EntryList } from '../EntryList';
+import type { EntryVm } from '../../../types/entry';
 
 describe('EntryList keyboard accessibility', () => {
-  const entries = [
+  const entries: EntryVm[] = [
     {
       id: 'e1',
       title: 'First Entry',
@@ -22,7 +22,7 @@ describe('EntryList keyboard accessibility', () => {
     const onSelect = vi.fn();
     render(
       <EntryList
-        entries={entries as any}
+        entries={entries}
         selectedEntry={null}
         onSelectEntry={onSelect}
         onCreateEntry={vi.fn()}
@@ -35,4 +35,3 @@ describe('EntryList keyboard accessibility', () => {
     expect(onSelect).toHaveBeenCalledWith('e1');
   });
 });
-

--- a/apps/web/src/components/markdown/__tests__/MarkdownSplitPane.autosave.test.tsx
+++ b/apps/web/src/components/markdown/__tests__/MarkdownSplitPane.autosave.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import React from 'react';
 
 // Mock the lazy-loaded MarkdownEditor with a simple textarea
 vi.mock('../MarkdownEditor', () => {
@@ -42,4 +41,3 @@ describe('MarkdownSplitPane autosave', () => {
     expect(onSave).toHaveBeenCalledWith({ html: '', markdown: '# New content' });
   });
 });
-

--- a/apps/web/src/config/flags.ts
+++ b/apps/web/src/config/flags.ts
@@ -1,0 +1,6 @@
+export const FLAGS = {
+  USER_MGMT_ENABLED:
+    (import.meta as any).env?.VITE_USER_MGMT_ENABLED === 'true' ||
+    (typeof process !== 'undefined' && (process as any).env?.VITE_USER_MGMT_ENABLED === 'true'),
+};
+

--- a/apps/web/src/services/authStore.ts
+++ b/apps/web/src/services/authStore.ts
@@ -1,0 +1,46 @@
+// Lightweight auth store with cross-tab sync via BroadcastChannel
+
+const bc: BroadcastChannel | null =
+  typeof window !== 'undefined' && 'BroadcastChannel' in window ? new BroadcastChannel('auth') : null;
+
+let accessToken: string | null = null;
+let refreshToken: string | null =
+  typeof window !== 'undefined' ? window.localStorage.getItem('refresh_token') : null;
+
+export function getAccessToken(): string | null {
+  return accessToken;
+}
+
+export function setAccessToken(token: string | null): void {
+  accessToken = token;
+  if (bc) bc.postMessage({ type: 'update', access: !!token });
+}
+
+export function getRefreshToken(): string | null {
+  return refreshToken;
+}
+
+export function setRefreshToken(token: string | null): void {
+  refreshToken = token;
+  if (typeof window !== 'undefined') {
+    if (token) window.localStorage.setItem('refresh_token', token);
+    else window.localStorage.removeItem('refresh_token');
+  }
+  if (bc) bc.postMessage({ type: 'update', refresh: !!token });
+}
+
+export function clearTokens(): void {
+  accessToken = null;
+  setRefreshToken(null);
+  if (bc) bc.postMessage({ type: 'logout' });
+}
+
+export function subscribe(fn: (evt: unknown) => void): () => void {
+  if (!bc) return () => {};
+  const handler = (e: MessageEvent) => fn(e.data);
+  bc.addEventListener('message', handler);
+  return () => bc.removeEventListener('message', handler);
+}
+
+export { bc };
+

--- a/apps/web/tests/e2e/auth-rotation.spec.ts
+++ b/apps/web/tests/e2e/auth-rotation.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Auth rotation & cross-tab', () => {
+  test('401 → refresh → retry succeeds, rotated refresh persisted', async ({ page }) => {
+    await page.goto('/');
+
+    // Assume backend has a test user created by API; perform login via API
+    const apiUrl = (process.env.VITE_API_URL as string) || 'http://localhost:5000/api';
+    const resp = await page.request.post(`${apiUrl}/v1/auth/login`, {
+      data: { email: 'rot@example.com', password: 'CorrectHorse9!' },
+    });
+    expect(resp.ok()).toBeTruthy();
+    const data = await resp.json();
+
+    await page.addInitScript((tokens) => {
+      localStorage.setItem('refresh_token', tokens.refresh);
+    }, { refresh: data.refresh_token });
+
+    await page.reload();
+
+    // Force one 401 for entries then allow
+    let first = true;
+    await page.route('**/api/v1/entries*', async (route) => {
+      if (first) {
+        first = false;
+        return route.fulfill({ status: 401, contentType: 'application/json', body: JSON.stringify({ message: 'expired' }) });
+      }
+      return route.fallback();
+    });
+
+    const [res] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/v1/entries') && r.status() !== 401),
+      page.evaluate((api) => fetch(`${api}/v1/entries`, { headers: { 'x-require-auth': '1' } }), apiUrl),
+    ]);
+    expect(res.ok()).toBeTruthy();
+
+    const rt = await page.evaluate(() => localStorage.getItem('refresh_token'));
+    expect(rt).not.toBe(data.refresh_token);
+  });
+
+  test('logout in tab A logs out tab B via BroadcastChannel', async ({ browser }) => {
+    const ctx = await browser.newContext();
+    const a = await ctx.newPage();
+    const b = await ctx.newPage();
+    await a.goto('/');
+    await b.goto('/');
+
+    await a.evaluate(() => localStorage.setItem('refresh_token', 'dummy'));
+    await b.evaluate(() => localStorage.setItem('refresh_token', 'dummy'));
+
+    await a.evaluate(() => {
+      const bc = new BroadcastChannel('auth');
+      bc.postMessage({ type: 'logout' });
+    });
+
+    await b.waitForFunction(() => !localStorage.getItem('refresh_token'));
+    await ctx.close();
+  });
+});
+

--- a/docs/USER_MANAGEMENT.md
+++ b/docs/USER_MANAGEMENT.md
@@ -1,0 +1,239 @@
+# User Management: Current State and Implementation Considerations
+
+This document summarizes the current user/authentication mechanics across the codebase and outlines key considerations for implementing full user management. The goal is to provide an objective, value‑dense reference for next steps, risks, and integration constraints from backend to frontend.
+
+## Executive Summary
+
+- Current auth is a minimal JWT-based demo implementation (no persisted users) with access/refresh tokens and a fixed demo credential flow.
+- Backend protects application routes via a lightweight `require_user` dependency that validates JWTs and passes a `user_id` through.
+- Frontend stores tokens in `localStorage`, attaches `Authorization: Bearer` headers, and auto-refreshes access tokens on 401.
+- Tests include scaffolds (skipped) for real user management, passkeys (WebAuthn), OAuth providers, and ownership enforcement.
+- Essential next steps: introduce persistent users, secure credential flows, session/refresh management, token rotation and revocation, and enforcement of ownership/roles in API.
+
+---
+
+## Current Capabilities (As Implemented)
+
+Backend (FastAPI):
+- Endpoints in `apps/api/app/api/v1/auth.py`:
+  - `POST /api/v1/auth/login`: Demo login using `JOURNAL_DEMO_USERNAME`/`JOURNAL_DEMO_PASSWORD` (defaults to `demo`/`demo123`). Returns access and refresh tokens for a fixed demo UUID.
+  - `POST /api/v1/auth/demo`: Returns tokens for the fixed demo user without credentials (dev convenience).
+  - `POST /api/v1/auth/refresh`: Validates refresh token and issues a new access token; returns the same refresh token (no rotation yet).
+  - `GET /api/v1/auth/me`: Returns a synthetic user profile based on `sub`.
+  - `POST /api/v1/auth/logout`: No server-side session state; returns success response only.
+- Token utilities in `apps/api/app/infra/auth.py`:
+  - HS256 JWT signing with `settings.jwt_secret`; claims include `iss`, `aud`, `iat`, `nbf`, `exp`, `sub`, `typ`.
+  - Access token TTL: `settings.access_token_minutes` (default 15m).
+  - Refresh token TTL: `settings.refresh_token_days` (default 30d).
+  - `require_user` FastAPI dependency (HTTP Bearer) validates JWT and returns `sub` as `user_id`.
+- Feature flag in `apps/api/app/settings.py`: `user_mgmt_enabled: bool = False` (scaffold for future).
+- Authorization usage:
+  - Protected endpoints depend on `require_user`, e.g., `entries`, `stats`, some `admin` routes.
+  - Ownership is implied via `Entry.author_id` set from `user_id` but not enforced across all operations yet.
+
+Frontend (React):
+- API service in `apps/web/src/services/api.ts`:
+  - Persists `access_token` and `refresh_token` in `localStorage`.
+  - Attaches `Authorization: Bearer <access_token>` on requests when `requireAuth` is true.
+  - On 401, attempts refresh via `POST /v1/auth/refresh`; if successful, retries original request.
+  - Provides `login`, `logout`, `checkAuthStatus` (calls `/v1/auth/me`), `demoLogin` (dev convenience).
+- App boot in `apps/web/src/components/JournalApp.tsx`:
+  - Calls `checkAuthStatus` on init; if unauthenticated, calls `demoLogin` during development and re-checks.
+  - UI renders unauthenticated state when tokens are absent/invalid.
+
+Tests (contracts for future work):
+- `apps/api/tests/integration/test_auth_user_management_scaffold.py` (skipped):
+  - Happy-path login/refresh/logout.
+  - Passkey registration/authentication (WebAuthn) placeholders.
+  - OAuth provider availability and connect flow placeholders.
+- `apps/api/tests/integration/test_permissions_scaffold.py` (skipped):
+  - Ownership enforcement: only entry owner can update/delete.
+
+---
+
+## Essential Structures in Code
+
+- Settings (`apps/api/app/settings.py`):
+  - `jwt_secret`, `jwt_iss`, `jwt_aud`, `access_token_minutes`, `refresh_token_days`.
+  - `user_mgmt_enabled` feature flag.
+  - Demo credentials: `demo_username`, `demo_password`.
+- Auth infra (`apps/api/app/infra/auth.py`):
+  - `create_access_token(sub, scopes?)`, `create_refresh_token(sub)`, `require_user`.
+  - Uses PyJWT; test mode can bypass exp verification (controlled by `settings.testing`).
+- Auth API (`apps/api/app/api/v1/auth.py`):
+  - Endpoints for demo login/refresh/me/logout as described above.
+- Domain models:
+  - `Entry` includes `author_id: UUID` (`apps/api/app/infra/models.py`). No `User` table defined yet.
+- Protected routes:
+  - `entries`, `stats`, and some `admin` endpoints use `require_user` dependency for access control.
+- Frontend API client:
+  - Centralized fetch wrapper with token attach/refresh (`apps/web/src/services/api.ts`).
+
+---
+
+## Backend Considerations for Full User Management
+
+Authentication and Identity:
+- Introduce persistent `User` model (SQLModel) with fields such as `id (UUID)`, `email`, `username`, `password_hash`, `created_at`, `updated_at`, `is_active`, `is_verified`.
+- Passwords: use strong hashing (e.g., Argon2id; at minimum, bcrypt with appropriate cost). Enforce password policy server-side.
+- Registration and verification: email verification (token/exp), optional invite codes for closed beta.
+- Login throttling and lockout after repeated failures (defend against credential stuffing).
+- MFA (optional later): TOTP or WebAuthn passkeys.
+
+Sessions, Tokens, and Revocation:
+- Access/refresh tokens should support rotation. On refresh:
+  - Issue new access token and a rotated refresh token.
+  - Persist refresh sessions (e.g., Redis or DB) with metadata (user_id, device, ip, exp, last_used).
+  - Revoke old refresh token; maintain a short grace window to handle race conditions.
+- Token invalidation on logout and password reset; maintain server-side denylist or session state.
+- Consider JWT key management and algorithm:
+  - Keep HS256 for simplicity with strong secret in prod or move to RS256/EC for key separation.
+
+Authorization and Ownership:
+- Enforce ownership on `entries` endpoints using `author_id == user_id` checks in repository/service layer.
+- Prepare for role-based access control (RBAC):
+  - `roles` (e.g., `user`, `admin`) and optional `permissions` granularity.
+  - Scope claims in JWT and route-level enforcement (e.g., `scope: "entries:read entries:write"`).
+
+Data Model and Migrations:
+- Add `User` table and optional `UserSession`/`RefreshToken` table.
+- Add FK constraint from `Entry.author_id` to `User.id` (nullable during migration; backfill demo UUID rows).
+- Write Alembic migrations with careful backfill/validation steps.
+
+Security Controls:
+- Validate and sanitize all inputs via Pydantic.
+- Rate limit auth endpoints and public endpoints.
+- CORS: limit to known origins in non-dev environments.
+- Logging/metrics: auth success/fail, refresh, logout, revocations, anomalous patterns.
+
+Operational Concerns:
+- Secret management via environment variables (never commit secrets). Rotate on compromise.
+- Observability: counters for auth flows, latency, error rates; traces for critical paths.
+
+---
+
+## Frontend Considerations
+
+Token Storage and Refresh:
+- Current storage uses `localStorage` for access/refresh tokens. This is simple but vulnerable to XSS.
+  - Consider moving to httpOnly, secure cookies (sameSite) for refresh tokens and keep access token in memory.
+  - If staying with storage, ensure robust XSS defenses and CSP.
+- The client retries a failed request after refresh. With rotation enabled, update client to persist the rotated refresh token.
+
+Auth Flows and UX:
+- Login: username/password form, error handling, lockout messaging.
+- Registration: email verification flow and resends.
+- Logout: call server, clear tokens reliably; handle cross-tab sync (storage events).
+- Session expiry: surface toast/banner when refresh fails; redirect to login.
+
+Ownership and Authorization UI:
+- Hide/disable update/delete actions for entries not owned by the user; show appropriate errors on server denial.
+- Admin-only UI surfaces gated by role flags returned from `/auth/me` or a profile endpoint.
+
+Provider Integrations:
+- Passkeys (WebAuthn): ceremony initiation endpoints, challenge signing; frontend uses WebAuthn APIs and passes results to verify endpoints.
+- OAuth providers: link buttons, provider availability checks, and redirect flows.
+
+---
+
+## API Contracts: Existing and Planned
+
+Existing (implemented):
+- `POST /api/v1/auth/login` → `{ access_token, refresh_token, token_type }`
+- `POST /api/v1/auth/refresh` → `{ access_token, refresh_token, token_type }`
+- `GET /api/v1/auth/me` → `{ id, username, email }`
+- `POST /api/v1/auth/logout` → `{ message }`
+
+Planned (scaffolded in tests):
+- Passkeys (WebAuthn):
+  - `POST /api/v1/auth/webauthn/register/options` → registration options incl. `challenge`.
+  - `POST /api/v1/auth/webauthn/register/verify` → completes registration.
+  - `POST /api/v1/auth/webauthn/authenticate/options` → authentication options.
+  - `POST /api/v1/auth/webauthn/authenticate/verify` → completes authentication.
+- OAuth providers:
+  - `GET /api/v1/auth/oauth/:provider/available`
+  - `POST /api/v1/auth/oauth/:provider/connect`
+- Ownership enforcement:
+  - `entries` update/delete return 401/403 when user is not the owner.
+
+---
+
+## Configuration and Environment
+
+Environment variables (see `apps/api/app/settings.py`):
+- `JOURNAL_JWT_SECRET`: Strong secret in production (required).
+- `JOURNAL_JWT_ISS` / `JOURNAL_JWT_AUD`: Issuer and audience.
+- `JOURNAL_ACCESS_TOKEN_MINUTES` / `JOURNAL_REFRESH_TOKEN_DAYS`: Token TTLs.
+- `JOURNAL_USER_MGMT_ENABLED`: Feature flag to gate new functionality.
+- `JOURNAL_DEMO_USERNAME` / `JOURNAL_DEMO_PASSWORD`: Development/demo overrides.
+
+Frontend:
+- API base derived from `VITE_API_URL`; client appends `/api` automatically.
+- Tokens persisted in `localStorage` by default; update strategy if moving to cookie-based refresh.
+
+---
+
+## Gaps and Risks (Objective)
+
+- No persisted users; demo-only identity tied to a fixed UUID.
+- No password hashing or credential storage; no registration/verification.
+- No server-side session state; no refresh token rotation; no revocation or device management.
+- Access/refresh tokens stored in `localStorage` → XSS exposure risk.
+- HS256 with default secret in repo; must be overridden in prod (risk if misconfigured).
+- Ownership is not enforced consistently on all write/delete operations.
+- No rate limiting on auth endpoints; potential brute-force risk.
+
+---
+
+## Implementation Roadmap (Phased)
+
+Phase 1: Foundations
+- Add `User` model + Alembic migrations; seed admin if needed.
+- Integrate password hashing (Argon2id preferred) and credential login.
+- Implement `/auth/register`, `/auth/verify-email`, `/auth/login` (password), `/auth/me`, `/auth/logout` with proper session semantics.
+- Introduce refresh token rotation with server-side session store (Redis/DB) and revocation on logout/reset.
+- Enforce ownership on `entries` update/delete; add 401/403 responses accordingly.
+
+Phase 2: Enhancements
+- Add OAuth providers abstraction (Google, GitHub) and link flows.
+- Add WebAuthn passkeys for registration and login; store credentials per user.
+- Add RBAC (roles/scopes) and surface in JWT claims; gate admin endpoints.
+- Strengthen CORS, rate limiting, telemetry, and audit logs.
+
+Phase 3: Hardening and UX
+- Move refresh to httpOnly secure cookies (if feasible) and keep access token in memory.
+- Add device/session management pages (list, revoke).
+- Add comprehensive tests (unit, component, integration, E2E) for all flows.
+
+---
+
+## Testing Strategy (Target)
+
+- Unit tests: token utils, password hashing, validators, session repository logic.
+- Component tests: FastAPI routes for auth/register/refresh/logout/me; entries ownership enforcement.
+- Integration tests: full login → refresh → logout; OAuth and WebAuthn via mocked ceremonies.
+- E2E: UI flows for login, registration, session expiry handling, and restricted actions.
+- Coverage target: ≥70% overall; do not exclude feature code.
+
+---
+
+## Backward Compatibility and Rollout
+
+- Keep demo login behind `JOURNAL_USER_MGMT_ENABLED=false` for local/tests; disable in prod.
+- Provide migration to map existing `Entry.author_id` demo UUID to real users or retain for dev-only data.
+- Maintain `/auth/me` response shape; add fields (e.g., `roles`) without breaking existing consumers.
+- Incrementally enforce ownership with feature flags and clear error messages in UI.
+
+---
+
+## References (Code Pointers)
+
+- Backend settings: `apps/api/app/settings.py`
+- Auth utilities: `apps/api/app/infra/auth.py`
+- Auth routes: `apps/api/app/api/v1/auth.py`
+- Protected routes examples: `apps/api/app/api/v1/entries.py`, `apps/api/app/api/v1/stats.py`, `apps/api/app/api/v1/admin.py`
+- Frontend API client: `apps/web/src/services/api.ts`
+- Tests (scaffolds):
+  - `apps/api/tests/integration/test_auth_user_management_scaffold.py`
+  - `apps/api/tests/integration/test_permissions_scaffold.py`
+

--- a/docs/USER_MANAGEMENT_IMPLEMENTATION.md
+++ b/docs/USER_MANAGEMENT_IMPLEMENTATION.md
@@ -1,0 +1,142 @@
+# User Management Implementation Plan
+
+This guide defines a pragmatic, phased implementation for full user management in the Journal monorepo. It builds on the current demo JWT flow and moves toward persistent users, secure sessions, ownership enforcement, and optional providers (OAuth, WebAuthn).
+
+The plan is objective, implementation-focused, and aligned with existing patterns, tooling, and testing practices in this repo.
+
+## Goals
+
+- Persisted users with secure password auth and optional providers.
+- Short‑lived access tokens; rotated refresh tokens with server-side session state and revocation.
+- Strict authorization and ownership on content.
+- Minimal disruption to existing routes; gradual rollout behind feature flags.
+- Comprehensive tests with ≥70% coverage on feature code.
+
+## Architecture Additions
+
+Data model (SQLModel in `apps/api/app/infra/models.py`):
+- User: `id (UUID)`, `email (unique)`, `username (unique, optional)`, `password_hash`, `is_active`, `is_verified`, timestamps.
+- RefreshSession: `id (UUID)`, `user_id (FK)`, `jti (unique)`, `revoked`, `expires_at`, `created_at`, optional device/agent metadata.
+- Optional (later): OAuthAccount, PasskeyCredential.
+
+Auth flow:
+- Password login: verify credentials, create access token (short TTL), create refresh session + refresh token (contains `jti`) and return.
+- Refresh: validate refresh token, check session by `jti`, rotate by issuing new refresh token and revoking old session entry; issue new access token.
+- Logout: revoke current refresh session; optionally all sessions if requested.
+- Ownership: enforce `author_id == user_id` for entry update/delete; list filters by `author_id`.
+
+Frontend:
+- Continue using bearer access tokens for API calls.
+- Support refresh rotation (persist rotated `refresh_token`), or move to httpOnly cookie for refresh in later phase.
+- Remove development auto‑login when `JOURNAL_USER_MGMT_ENABLED=true`.
+
+## Backend Tasks
+
+1) Models and Migrations
+- Add `User` and `RefreshSession` to `app/infra/models.py`.
+- Create Alembic migration: create tables and indexes; optionally backfill an admin user for development.
+- Transitional step: keep existing demo login while `settings.user_mgmt_enabled == False`.
+
+2) Security Primitives
+- Password hashing: Argon2id (preferred) via `argon2-cffi` or `argon2-cffi-bindings`. If not available, bcrypt as fallback.
+- JWTs: Include `jti` in refresh tokens; consider RS256 later (HS256 acceptable with strong secret).
+- Rate limiting (optional in near-term): use a simple in‑memory or Redis limiter for `/auth/login` and `/auth/refresh`.
+
+3) Session Management
+- Create session on login; store `(user_id, jti, expires_at, revoked=False)`.
+- On refresh: verify token, find session by `jti`, ensure not revoked and not expired; issue new `jti`, persist new session, revoke old one; return new refresh token + new access token.
+- On logout: revoke session (by `jti`).
+
+4) API Endpoints (FastAPI)
+- `POST /api/v1/auth/register` (optional phase 1): create user, send verification (stub or real email flow); return pending/created.
+- `POST /api/v1/auth/login`: password login with session creation and token pair issuance.
+- `POST /api/v1/auth/refresh`: rotate refresh token and return new tokens.
+- `GET /api/v1/auth/me`: return user profile + roles/scopes; stable shape with additive fields.
+- `POST /api/v1/auth/logout`: revoke current session; return success.
+- `GET /api/v1/auth/sessions`: list active sessions for the user (optional, phase 2).
+- `POST /api/v1/auth/sessions/{id}/revoke`: revoke a specific session (optional, phase 2).
+
+5) Authorization & Ownership
+- Repository or service layer checks to ensure modifying/deleting entries require ownership.
+- Consider basic RBAC: `roles` claim in access token (`user`, `admin`) to guard admin endpoints.
+
+6) Observability & Security
+- Metrics: login success/fail, refresh success/fail, logout, revocations.
+- Logging: structured logs with minimal PII.
+- CORS: restrict in non-dev.
+- Secrets: ensure `JOURNAL_JWT_SECRET` set in production; never commit secrets.
+
+## Frontend Tasks
+
+1) Token Handling
+- Update refresh logic to accept and persist rotated `refresh_token` (already supported by current API client if response includes it).
+- In a future phase, move refresh token to secure httpOnly cookie; then stop storing refresh token in `localStorage` and update API client accordingly.
+
+2) Auth UI
+- Login form: email/username + password; errors on invalid credentials; lockout messaging on throttling.
+- Registration form (optional P1); email verification flow in P2.
+- Session expiry: when refresh fails, clear tokens and show login screen.
+- Remove dev `demoLogin()` fallback when `JOURNAL_USER_MGMT_ENABLED=true`.
+
+3) Ownership in UI
+- Hide or disable actions (update/delete) for entries not owned by the user; handle server 403 gracefully.
+
+## Configuration
+
+Backend (`apps/api/app/settings.py`):
+- `user_mgmt_enabled: bool` – feature flag.
+- `jwt_secret: str` – must be strong in production.
+- `access_token_minutes: int` – default 15.
+- `refresh_token_days: int` – default 30.
+- Additions:
+  - `password_hash_scheme: str = "argon2"` (or "bcrypt").
+  - `refresh_cookie_enabled: bool = False`
+  - `refresh_cookie_name: str = "jr_refresh"`
+  - `refresh_cookie_secure: bool = True`
+  - `refresh_cookie_samesite: str = "lax"`
+
+Frontend:
+- `VITE_API_URL`
+- If cookie-based refresh is enabled, client should not store refresh token.
+
+## Testing Strategy
+
+- Unit: hashing, token create/verify, session repo logic, permission checks.
+- Component (API): register/login/refresh/logout/me; ownership enforcement on `entries`.
+- Integration: rotation and revocation flows; invalid/expired tokens.
+- E2E: login, session expiry, logout, restricted actions.
+- Convert scaffolded integration tests from skipped to active as features land.
+
+## Rollout Plan
+
+Phase 1 (Foundations):
+- Add models/migrations, credential login, sessions, rotation, logout, basic `/me`, enforce ownership, metrics/logging.
+- Keep demo login behind `user_mgmt_enabled=false` and disabled in prod.
+
+Phase 2 (Enhancements):
+- Sessions management endpoints, email verification, OAuth provider abstraction, WebAuthn passkeys.
+
+Phase 3 (Hardening):
+- Cookie-based refresh, device management UI, RBAC enforcement on admin routes, rate limiting.
+
+## Commands (Python API)
+
+Using uv (never pip/poetry):
+- `cd apps/api && uv run alembic revision --autogenerate -m "add user and refresh sessions"`
+- Review migration; then `cd apps/api && uv run alembic upgrade head`
+- Run tests: `cd apps/api && uv run pytest -m "unit or component"`
+
+## Minimal Endpoint Contracts
+
+- `POST /api/v1/auth/login` → `{ access_token, refresh_token, token_type }`
+- `POST /api/v1/auth/refresh` → `{ access_token, refresh_token, token_type }` (rotated)
+- `GET /api/v1/auth/me` → `{ id, email, username, roles?: string[] }`
+- `POST /api/v1/auth/logout` → `{ message }`
+
+Keep shapes stable and additive to avoid frontend breakage.
+
+## Code Pointers
+
+- Existing: `app/infra/auth.py`, `app/api/v1/auth.py`, `app/infra/models.py`, `app/api/v1/entries.py`, `web/src/services/api.ts`.
+- New: Models + session repo, updated auth routes, optional cookie helpers.
+

--- a/docs/USER_MANAGEMENT_ORCHESTRATEV1.md
+++ b/docs/USER_MANAGEMENT_ORCHESTRATEV1.md
@@ -1,0 +1,297 @@
+# Phase 0 — Stabilize the docs branch & stage the work
+
+### 0.1 Open a docs-only PR (no runtime changes)
+
+```bash
+# Ensure you’re up to date
+git fetch origin
+
+# Create PR for docs branch
+codex open-pr \
+  --base main \
+  --head docs/user-management-report \
+  --title "docs(auth): user management plan + starter diffs" \
+  --labels docs,auth,planning \
+  --body "Adds implementation plan and starter diffs; no behavior change."
+```
+
+### 0.2 Recover/inspect any stash safely (if it exists)
+
+```bash
+# If agent mentioned a stash, land it on a temp branch for review
+git checkout -b wip/agent-stash-landing
+git stash list  # if entries exist:
+git stash show -p | git apply -3  # or: git stash pop (only if you're ready)
+git commit -am "chore: land agent stash for inspection"
+git push -u origin wip/agent-stash-landing
+```
+
+---
+
+# Phase 1 — Create implementation tracks (M1.\*) as small PRs
+
+> We’ll align to the repo’s existing file layout **and** the agent’s docs. Your repo currently centralizes models; we’ll keep **`User` & `UserSession`** in `apps/api/app/infra/models.py` as the docs suggest (instead of a new file), and add migrations. Rotation/jti goes into `infra/auth.py`. Ownership checks go into `api/v1/entries.py`.
+
+### 1.0 Create baseline feature flags in all envs (no behavior change)
+
+```bash
+mise env set JOURNAL_USER_MGMT_ENABLED=false JOURNAL_AUTH_ENABLE_PASSKEYS=false JOURNAL_AUTH_ENABLE_OAUTH=false JOURNAL_AUTH_COOKIE_REFRESH=false JOURNAL_PRIVACY_DASHBOARD=false
+```
+
+---
+
+## M1.T1 — Persistent Users + Sessions schema
+
+### 1.1 Branch & plan
+
+```bash
+git checkout -b feat/auth-M1.T1-users-sessions
+codex plan --milestones M1_foundations --filter "T1"
+```
+
+### 1.2 Apply model + migration (≤300 LoC diff)
+
+```bash
+codex edit <<'BRIEF'
+Goal: Add User and UserSession (a.k.a. RefreshSession) to apps/api/app/infra/models.py and create Alembic migration.
+- Keep columns: id (UUID), email unique, username?, password_hash?, roles JSON, is_active, is_verified, created_at, updated_at.
+- UserSession: id, user_id FK, refresh_id (UUID unique), user_agent, ip_address, issued_at, last_used_at, expires_at, revoked_at.
+- Ensure models are imported at app startup so Alembic can autogenerate.
+- Generate migration file apps/api/alembic/versions/20250909_0001_users_sessions.py.
+Add unit test apps/api/tests/unit/test_user_model.py (defaults).
+Do NOT change handlers or behavior yet.
+BRIEF
+```
+
+### 1.3 Run unit & migration sanity
+
+```bash
+alembic -c apps/api/alembic.ini upgrade head
+pytest -q apps/api/tests/unit/test_user_model.py
+codex open-pr -m "feat(auth): User + UserSession models and migration (M1.T1)" --labels auth,db,migrations
+```
+
+---
+
+## M1.T2 — Registration + Email Verify + Password Login (Argon2id)
+
+### 2.1 Branch & plan
+
+```bash
+git checkout -b feat/auth-M1.T2-register-login
+codex plan --milestones M1_foundations --filter "T2"
+```
+
+### 2.2 Implement endpoints under flag
+
+```bash
+codex edit <<'BRIEF'
+Goal: Add register/verify/login endpoints in apps/api/app/api/v1/auth.py behind JOURNAL_USER_MGMT_ENABLED.
+- /register: create user; return 202 and dev_verify_token when testing/dev.
+- /verify-email: consume verify token; set is_verified true.
+- /login: verify Argon2id hash; return access+refresh (temp, no rotation yet).
+- Add hashing helpers in apps/api/app/infra/security.py (argon2).
+- Extend auth utils in apps/api/app/infra/auth.py to create verify tokens.
+- Rate-limit /register and /login with simple in-proc guard (keep minimal).
+- Tests: apps/api/tests/integration/test_auth_password_flow.py happy path.
+No impact when JOURNAL_USER_MGMT_ENABLED=false.
+BRIEF
+```
+
+### 2.3 Run integration tests
+
+```bash
+pytest -q apps/api/tests/integration/test_auth_password_flow.py
+codex open-pr -m "feat(auth): register/verify/login (M1.T2, flagged)" --labels auth,backend
+```
+
+---
+
+## M1.T3 — Refresh Rotation + Server Sessions + Revocation
+
+### 3.1 Branch & plan
+
+```bash
+git checkout -b feat/auth-M1.T3-rotation
+codex plan --milestones M1_foundations --filter "T3"
+```
+
+### 3.2 Implement rotation flow
+
+```bash
+codex edit <<'BRIEF'
+Goal: Implement refresh rotation and revocation using UserSession.refresh_id (JTI) in apps/api/app/api/v1/auth.py.
+- On /login: create UserSession with UA/IP; issue access + refresh(jwt rid=session.refresh_id).
+- /refresh: verify refresh; lookup session by rid; rotate rid to new UUID; issue new tokens; revoke old session state.
+- /logout: revoke current session via rid.
+- Add session helpers in apps/api/app/infra/sessions.py (create/touch/revoke/get_by_rid).
+- Tests: apps/api/tests/integration/test_refresh_rotation.py
+**Keep behind JOURNAL_USER_MGMT_ENABLED.** Do not break demo endpoints when flag is false.
+BRIEF
+```
+
+### 3.3 Run rotation tests
+
+```bash
+pytest -q apps/api/tests/integration/test_refresh_rotation.py
+codex open-pr -m "feat(auth): refresh rotation, sessions, logout (M1.T3, flagged)" --labels auth,sessions,security
+```
+
+---
+
+# Phase 2 — Ownership enforcement (M1 remainder)
+
+> The agent’s doc says entries write/delete are being enforced. Do it now with a tiny PR.
+
+### 4.0 Ownership enforcement PR
+
+```bash
+git checkout -b feat/auth-M1.own
+codex edit <<'BRIEF'
+Goal: Enforce author ownership on entries update/delete.
+- apps/api/app/api/v1/entries.py: ensure current_user == entry.author_id; else 403.
+- Unskip tests in apps/api/tests/integration/test_permissions_scaffold.py; make pass.
+**Guard by JOURNAL_USER_MGMT_ENABLED to avoid affecting demo until rollout.**
+BRIEF
+```
+
+```bash
+pytest -q apps/api/tests/integration/test_permissions_scaffold.py
+codex open-pr -m "feat(auth): entries ownership enforcement (M1)" --labels auth,authorization
+```
+
+---
+
+# Phase 3 — Frontend minimal wiring for rotation (safe/flagged)
+
+> We keep it small: persist rotated refresh token and remove auto-demo login when the flag is on.
+
+### 5.0 Frontend PR
+
+```bash
+git checkout -b feat/web-auth-rotation-min
+codex edit <<'BRIEF'
+Goal: Update apps/web/src/services/api.ts to:
+- Expect rotated refresh_token from /auth/refresh and persist it.
+- On 401, call /auth/refresh with current refresh; retry original request.
+- When JOURNAL_USER_MGMT_ENABLED=true, disable demo auto-login in JournalApp.tsx; when false, keep current dev behavior.
+Add a Playwright smoke test for expired access -> refresh -> retry success.
+BRIEF
+```
+
+```bash
+pnpm -C apps/web test -u --run
+pnpm -C apps/web exec playwright test --reporter=line
+codex open-pr -m "feat(web): client refresh rotation + guard demo auto-login (M1)" --labels frontend,auth
+```
+
+---
+
+# Phase 4 — Merge order & rollout switches
+
+### 6.0 Merge order (all green)
+
+1. **M1.T1 models+migration**
+2. **M1.T2 register/login**
+3. **M1.T3 rotation**
+4. **Ownership enforcement**
+5. **Frontend rotation**
+
+> After each merge, run DB migrations in **dev** and **staging**; prod later.
+
+### 6.1 Enable staging flags
+
+```bash
+# staging only
+mise env set JOURNAL_USER_MGMT_ENABLED=true
+# keep passkeys/oauth/cookies OFF for now
+```
+
+### 6.2 Smoke checklist (staging)
+
+* Register → verify → login → `/auth/me` ok.
+* Access expiry → `/auth/refresh` rotates → old refresh rejected.
+* Logout → refresh rejected.
+* Non-owner entry update/delete → 403.
+* Frontend: 401 triggers refresh → retry succeeds.
+
+---
+
+# Phase 5 — Security & observability add-ons (tiny PRs)
+
+### 7.0 Add metrics counters (server)
+
+```bash
+git checkout -b feat/auth-metrics
+codex edit <<'BRIEF'
+Add minimal counters in apps/api/app/infra/metrics.py and increment in auth routes:
+- auth_login_success_total, auth_login_fail_total
+- auth_refresh_rotations_total, auth_revocations_total
+Expose /metrics if already supported or wire into existing exporter.
+BRIEF
+```
+
+```bash
+codex open-pr -m "feat(auth): minimal auth metrics counters"
+```
+
+### 7.1 Rate limit guards
+
+```bash
+git checkout -b feat/auth-ratelimit
+codex edit <<'BRIEF'
+Add simple rate limiting to /register and /login (window: 60s, max: 5) using existing middleware or a lightweight in-memory map when REDIS_URL not set. Generic 429 message.
+BRIEF
+```
+
+```bash
+codex open-pr -m "feat(auth): rate limit /register and /login"
+```
+
+---
+
+# Phase 6 — Governance & backout
+
+* Flags are the backout: set `JOURNAL_USER_MGMT_ENABLED=false` to instantly fall back to demo flows (no schema rollback).
+* To invalidate all sessions: admin script sets `revoked_at` for all **active** `user_sessions`.
+
+---
+
+## Codex “one-liners” you can reuse
+
+**Ask codex to generate migration from models (if you prefer autogen):**
+
+```bash
+alembic -c apps/api/alembic.ini revision --autogenerate -m "users + user_sessions"
+alembic -c apps/api/alembic.ini upgrade head
+```
+
+**Security checklist before merging any auth PR:**
+
+```bash
+codex checklist run security <<'SEC'
+- Secrets from env; no new hardcoded secrets.
+- Rate limiting on /auth endpoints present.
+- Refresh rotation implemented; old refresh unusable post-rotation.
+- Logout revokes session.
+- JWT 'typ' validated ('access' vs 'refresh'); audience checked.
+- CSP unchanged or tightened; no unsafe-inline introduced.
+- Tests passing: unit, integration, e2e on auth flows.
+SEC
+```
+
+---
+
+## Small reconciliation notes (so nothing slips)
+
+* **Models location:** use `apps/api/app/infra/models.py` (as in your docs). If you had already created `models_user.py` in a prior branch, codex can merge them back into `models.py` to avoid dual sources of truth.
+* **Naming:** `UserSession` vs `RefreshSession`—choose one (I recommend `UserSession`) and keep it consistent across schema, repo, and tests.
+* **Demo auth:** keep demo endpoints callable when `JOURNAL_USER_MGMT_ENABLED=false` to preserve local workflows while you roll out.
+* **Rotation grace:** we’re using **no grace** for simplicity and security (old refresh invalid immediately). If you want a 10s grace later, we’ll add a scheduled revoke in M4.
+
+---
+
+### Answer to the question:
+
+**Yes—open the docs PR now.** Then execute the branches/PRs above in the exact order. No stash restoration into working branches; land any stash to `wip/agent-stash-landing` only for inspection. Once M1 merges to staging with flags on, I’ll green-light M2 (passkeys) and M4 (cookie refresh) as separate tracks.
+

--- a/docs/USER_MANAGEMENT_STARTER_DIFFS.md
+++ b/docs/USER_MANAGEMENT_STARTER_DIFFS.md
@@ -1,0 +1,338 @@
+# User Management Starter Diffs
+
+This document provides minimal, focused diffs to bootstrap the user management implementation while keeping changes aligned with current architecture. These diffs are illustrative and should be adapted during development/migration review.
+
+Note: Paths reflect current code locations (e.g., models live in `app/infra/models.py`).
+
+---
+
+## 1) Models: User and RefreshSession
+
+File: `apps/api/app/infra/models.py`
+
+```diff
+@@
+ from sqlmodel import SQLModel, Field
++from typing import Optional
++from uuid import UUID, uuid4
++from datetime import datetime
+
+@@
+ class Entry(SQLModel, table=True):
+     # ... existing fields ...
+     author_id: UUID = Field(index=True)
+
++
++class User(SQLModel, table=True):
++    __tablename__ = "users"
++
++    id: UUID = Field(default_factory=uuid4, primary_key=True, nullable=False)
++    email: str = Field(index=True, unique=True, nullable=False)
++    username: Optional[str] = Field(default=None, unique=True)
++    password_hash: str = Field(nullable=False)
++    is_active: bool = Field(default=True)
++    is_verified: bool = Field(default=False)
++    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
++    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
++
++
++class RefreshSession(SQLModel, table=True):
++    __tablename__ = "refresh_sessions"
++
++    id: UUID = Field(default_factory=uuid4, primary_key=True, nullable=False)
++    user_id: UUID = Field(foreign_key="users.id", index=True, nullable=False)
++    jti: str = Field(unique=True, index=True, nullable=False)
++    revoked: bool = Field(default=False, nullable=False)
++    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
++    expires_at: datetime = Field(nullable=False)
++    user_agent: Optional[str] = None
++    ip_address: Optional[str] = None
+```
+
+Migration: `uv run alembic revision --autogenerate -m "add user and refresh sessions"` then review and `uv run alembic upgrade head`.
+
+---
+
+## 2) Settings: Feature flags and cookie toggles
+
+File: `apps/api/app/settings.py`
+
+```diff
+@@
+ class Settings(BaseSettings):
+@@
+     refresh_token_days: int = 30
+@@
+     user_mgmt_enabled: bool = False
+@@
+     demo_username: str = "demo"
+     demo_password: str = ""  # Set JOURNAL_DEMO_PASSWORD in env for non-empty
++
++    # User management additions
++    password_hash_scheme: str = "argon2"  # or "bcrypt"
++    refresh_cookie_enabled: bool = False
++    refresh_cookie_name: str = "jr_refresh"
++    refresh_cookie_secure: bool = True
++    refresh_cookie_samesite: str = "lax"
+```
+
+---
+
+## 3) Auth Infra: jti, rotation scaffolds
+
+File: `apps/api/app/infra/auth.py`
+
+```diff
+@@
+ from datetime import UTC, datetime, timedelta
+ from typing import Any
+@@
+ def create_access_token(sub: str, scopes: list[str] | None = None) -> str:
+@@
+     return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+-
+ def create_refresh_token(sub: str) -> str:
+-    now = _utcnow()
+-    payload = {
+-        "iss": settings.jwt_iss,
+-        "aud": settings.jwt_aud,
+-        "iat": int(now.timestamp()),
+-        "nbf": int(now.timestamp()),
+-        "exp": int((now + timedelta(days=settings.refresh_token_days)).timestamp()),
+-        "sub": sub,
+-        "typ": "refresh",
+-    }
+-    return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
++    """Issue a refresh token with unique jti for session tracking."""
++    now = _utcnow()
++    jti = jwt.utils.base64url_encode(jwt.utils.force_bytes(str(now.timestamp()))).decode()
++    payload = {
++        "iss": settings.jwt_iss,
++        "aud": settings.jwt_aud,
++        "iat": int(now.timestamp()),
++        "nbf": int(now.timestamp()),
++        "exp": int((now + timedelta(days=settings.refresh_token_days)).timestamp()),
++        "sub": sub,
++        "jti": jti,
++        "typ": "refresh",
++    }
++    return jwt.encode(payload, settings.jwt_secret, algorithm="HS256")
+
+@@
+ def require_user(creds: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> str:
+@@
+     except jwt.PyJWTError as e:
+         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from e
+
+ # Alias for compatibility
+ get_current_user = require_user
+```
+
+Note: In implementation, persist `jti` to `RefreshSession` on login and verify on refresh, then rotate (re-issue refresh token with new `jti`).
+
+---
+
+## 4) Auth API: login/refresh/logout scaffolds with sessions
+
+File: `apps/api/app/api/v1/auth.py`
+
+```diff
+@@
+ router = APIRouter(prefix="/auth", tags=["auth"])
+@@
+ @router.post("/login")
+ async def login(body: LoginRequest) -> dict[str, str]:
+-    """Password login (demo: credentials via settings, defaults for dev)."""
+-    expected_user = settings.demo_username or "demo"
+-    expected_pass = settings.demo_password or ("demo" + "123")  # not a real secret
+-    if body.username == expected_user and body.password == expected_pass:
+-        user_id = "123e4567-e89b-12d3-a456-426614174000"
+-    else:
+-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+-    return {
+-        "access_token": create_access_token(user_id),
+-        "refresh_token": create_refresh_token(user_id),
+-        "token_type": "bearer",
+-    }
++    """Password login (demo fallback when user_mgmt_disabled)."""
++    if not settings.user_mgmt_enabled:
++        expected_user = settings.demo_username or "demo"
++        expected_pass = settings.demo_password or ("demo" + "123")
++        if body.username != expected_user or body.password != expected_pass:
++            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
++        user_id = "123e4567-e89b-12d3-a456-426614174000"
++        return {"access_token": create_access_token(user_id), "refresh_token": create_refresh_token(user_id), "token_type": "bearer"}
++
++    # TODO: Replace with DB lookup of User + password verification (argon2/bcrypt)
++    # user = await users_repo.get_by_email_or_username(body.username)
++    # if not user or not verify_password(body.password, user.password_hash):
++    #     raise HTTPException(status_code=401, detail="Invalid credentials")
++    # session = await sessions_repo.create_for_user(user.id, jti)
++    # return tokens with jti embedded in refresh token
+
+@@
+ @router.post("/refresh")
+ async def refresh(body: RefreshRequest) -> dict[str, str]:
+-    """Exchange a valid refresh token for a new access token."""
++    """Exchange a valid refresh token for a new access token (rotation planned)."""
+@@
+-    return {
+--        "access_token": create_access_token(sub),
+--        "refresh_token": body.refresh_token,
+--        "token_type": "bearer",
+--    }
++    # TODO: Verify jti against RefreshSession, ensure not revoked, rotate jti and return new refresh token
++    return {"access_token": create_access_token(sub), "refresh_token": body.refresh_token, "token_type": "bearer"}
+
+@@
+ @router.post("/logout")
+ async def logout(user_id: str = Depends(get_current_user)) -> dict[str, str]:
+-    # In a real app, you might invalidate the token in Redis
+-    return {"message": "Logged out successfully"}
++    # TODO: Revoke current refresh session (by jti) if available
++    return {"message": "Logged out successfully"}
+```
+
+---
+
+## 5) Entries API: enforce ownership on update/delete
+
+File: `apps/api/app/api/v1/entries.py`
+
+```diff
+@@
+ async def update_entry(
+@@
+     repo = EntryRepository(s)
++    # Ownership check (starter): ensure current user is the author
++    # TODO: Consider moving this to service/repository layer for reuse
++    existing = await repo.get_by_id(eid)
++    if not existing or existing.author_id != UUID(user_id):
++        raise HTTPException(status_code=403, detail="Forbidden")
+
+@@
+ async def delete_entry(
+@@
+     repo = EntryRepository(s)
+
++    # Ownership check (starter)
++    row = await repo.get_by_id(eid)
++    if not row or row.author_id != UUID(user_id):
++        raise HTTPException(status_code=403, detail="Forbidden")
+
+     try:
+         await repo.soft_delete(eid, expected_version)
+         await s.commit()
+```
+
+Note: In a refined implementation, centralize ownership checks and return 404 instead of 403 to avoid leaking existence.
+
+---
+
+## 6) Frontend: refresh rotation support (already compatible)
+
+File: `apps/web/src/services/api.ts`
+
+```diff
+@@
+   private setTokens(tokens: AuthTokens) {
+     localStorage.setItem('access_token', tokens.access_token);
+-    if (tokens.refresh_token) {
+-      localStorage.setItem('refresh_token', tokens.refresh_token);
+-    }
++    // Store rotated refresh tokens when returned
++    if (tokens.refresh_token) localStorage.setItem('refresh_token', tokens.refresh_token);
+   }
+@@
+   private async refreshToken(): Promise<void> {
+     const refreshToken = localStorage.getItem('refresh_token');
+     if (!refreshToken) return;
+@@
+       const tokens = await this.request<AuthTokens>(
+         '/v1/auth/refresh',
+@@
+       );
+       this.setTokens(tokens);
+     } catch (_error) {
+       this.clearTokens();
+     }
+   }
+```
+
+Optional (later): When refresh is moved to httpOnly cookies, remove storage/passing of `refresh_token` and rely on cookie.
+
+---
+
+## 7) JournalApp: remove demo auto-login when feature enabled
+
+File: `apps/web/src/components/JournalApp.tsx`
+
+```diff
+@@
+   useEffect(() => {
+     const initializeApp = async () => {
+       try {
+         const authStatus = await api.checkAuthStatus();
+ 
+-        if (!authStatus.authenticated) {
+-          // Try demo login for development
+-          await api.demoLogin();
+-          const newAuthStatus = await api.checkAuthStatus();
+-          setState((prev) => ({
+-            ...prev,
+-            authenticated: newAuthStatus.authenticated,
+-            user: newAuthStatus.user,
+-            loading: false,
+-          }));
+-        } else {
+-          setState((prev) => ({
+-            ...prev,
+-            authenticated: authStatus.authenticated,
+-            user: authStatus.user,
+-            loading: false,
+-          }));
+-        }
++        setState((prev) => ({
++          ...prev,
++          authenticated: authStatus.authenticated,
++          user: authStatus.user,
++          loading: false,
++        }));
+```
+
+If demo login is still desired in dev, guard with an env/flag exposed from the backend (`/auth/config` or `settings.user_mgmt_enabled`).
+
+---
+
+## 8) Tests: unskip scaffolds incrementally
+
+Files:
+- `apps/api/tests/integration/test_auth_user_management_scaffold.py`
+- `apps/api/tests/integration/test_permissions_scaffold.py`
+
+Actions:
+- As features land, remove `@pytest.mark.skip` and adapt assertions to real implementations.
+- Add unit coverage for hashing, token issuance/verify, session repo logic.
+
+---
+
+## 9) Migration Backfill (Optional)
+
+If existing entries use the demo UUID, choose one:
+- Map demo UUID to a created `demo@local` user (dev only), or
+- Keep demo data separate and only enforce ownership for new entries when user management is enabled.
+
+---
+
+## 10) Operational Notes
+
+- Require `JOURNAL_JWT_SECRET` in production; rotate on compromise.
+- Consider moving refresh to secure httpOnly cookie in Phase 3.
+- Rate limit `/auth/login`, `/auth/refresh`.
+- Add metrics and basic audit logs.
+
+---
+
+These diffs provide a safe starting point. Flesh out repositories/services, add migrations, and wire tests as the next concrete steps.
+


### PR DESCRIPTION
## What
- Moves refresh tokens to httpOnly cookies when `JOURNAL_AUTH_COOKIE_REFRESH=true`
- Adds double-submit CSRF: `csrftoken` cookie + `X-CSRF-Token` header
- `/login` (flag on): sets `refresh_token` cookie + `csrftoken`; returns `access_token` only
- `/refresh` (flag on): reads cookie, rotates rid, returns `access_token` only, resets cookie
- `/logout` (flag on): requires CSRF header; revokes session; clears cookie; 204
- Frontend: `credentials: 'include'` in cookie mode; no refresh in JS; auto-sets `X-CSRF-Token` for unsafe verbs; M1 body flow retained when flag off

## Why
Reduce token exfiltration risk (httpOnly) and add CSRF protection, keeping access in memory.

## Flags
- API: `JOURNAL_AUTH_COOKIE_REFRESH=true`
- Web: `VITE_AUTH_COOKIE_REFRESH=true`

## Validation
- Login sets cookie (`Path=/api/v1/auth`, `SameSite=Lax`, `HttpOnly`, `Secure` per env)
- Refresh rotates rid; returns only access
- Logout requires matching `X-CSRF-Token`; clears cookie
- Flag off → legacy body refresh unchanged

## Follow-ups
Optionally apply CSRF guard to non-auth write routes under same flag.

## Reviewer Checklist
```
- [ ] Set-Cookie: refresh_token has HttpOnly, SameSite=Lax, Path=/api/v1/auth, Secure in non-dev
- [ ] /refresh reads cookie only, rotates rid, returns access only
- [ ] /logout 403 without CSRF header; 204 with correct header; cookie cleared
- [ ] Web sends credentials:'include' and adds X-CSRF-Token on unsafe verbs
- [ ] No refresh token written to localStorage in cookie mode
- [ ] Flag off preserves prior behavior and tests
```