### PR TITLE
fix: update GitHub Actions to resolve deprecation failures

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   lint-and-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: apps/api
@@ -52,7 +52,7 @@ jobs:
         run: uv run mypy app/
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: apps/api
@@ -138,7 +138,7 @@ jobs:
         run: uv cache prune --ci
 
   integration-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [lint-and-format, test]
     defaults:
       run:
@@ -215,7 +215,7 @@ jobs:
           JOURNAL_JWT_SECRET: test-secret-key-for-integration
 
   security-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: apps/api

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   unit_component:
     name: Unit + Component
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -62,7 +62,7 @@ jobs:
 
   integration:
     name: Integration
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   build-test:
     name: Lint, Typecheck, Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       CI: true
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,13 +24,13 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -66,15 +66,15 @@ jobs:
           cp -r docs/js-api _site/js-api
       
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: _site
 
   # Deployment job
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-fetch.yml
+++ b/.github/workflows/docs-fetch.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   fetch-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/documentation-checks.yml
+++ b/.github/workflows/documentation-checks.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   lint-and-check-links:
     name: Lint Markdown & Check Links
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/documentation-validate.yml
+++ b/.github/workflows/documentation-validate.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   validate-structure:
     name: Validate Documentation Structure
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: apps/web

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     name: API Lint/Type
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: apps/api

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -40,7 +40,7 @@ jobs:
   
   security-scan:
     name: Security Baseline
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       has_security_issues: ${{ steps.security.outputs.issues_found }}
@@ -93,7 +93,7 @@ jobs:
   
   api-quality:
     name: API Quality Gates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: security-scan
     timeout-minutes: 15
     outputs:
@@ -211,7 +211,7 @@ jobs:
   
   web-quality:
     name: Web Quality Gates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: security-scan
     timeout-minutes: 10
     outputs:
@@ -271,7 +271,7 @@ jobs:
   
   quality-summary:
     name: Quality Gate Summary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [security-scan, api-quality, web-quality]
     if: always()
     outputs:
@@ -346,7 +346,7 @@ jobs:
   
   performance-gates:
     name: Performance Quality Gates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: quality-summary
     if: needs.quality-summary.outputs.quality_gate == 'true' && !inputs.skip_performance
     timeout-minutes: 20

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   biome-and-types:
     name: Biome and TypeScript
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,15 +39,13 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
           body: |
             Release ${{ github.ref_name }}
             
             See the commits for a detailed changelog.
           draft: false
           prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/web-tests.yml
+++ b/.github/workflows/web-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   unit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: apps/web
@@ -81,7 +81,7 @@ jobs:
           path: apps/web/reports/junit.xml
 
   playwright:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     services:
       postgres:


### PR DESCRIPTION
## Summary
Fixes CI failures caused by GitHub's v3 artifact action deprecation block (effective Jan 30, 2025).

## Changes
- ✅ Updated all workflows to use `ubuntu-24.04` instead of `ubuntu-latest`
- ✅ Updated GitHub Pages actions to latest versions:
  - `actions/configure-pages@v5` (was v3)
  - `actions/upload-pages-artifact@v3` (was v2)
  - `actions/deploy-pages@v4` (was v2)
- ✅ Replaced deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
- ✅ Verified all artifact and cache actions already on v4

## Impact
This resolves the immediate CI failures blocking all PRs. All workflows should now run successfully with modern, supported action versions.

## References
- [GitHub deprecation notice for v3 artifact actions](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)
- [GitHub Pages actions requiring v4](https://github.blog/changelog/2024-12-05-deprecation-notice-github-pages-actions-to-require-artifacts-actions-v4-on-github-com/)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>